### PR TITLE
Add typing module

### DIFF
--- a/demotivator/typing.py
+++ b/demotivator/typing.py
@@ -12,3 +12,5 @@ class Font(Protocol):
 
 
 RGB: TypeAlias = tuple[int, int, int] | tuple[int, int, int, int]
+
+Ink: TypeAlias = str | int | RGB

--- a/demotivator/typing.py
+++ b/demotivator/typing.py
@@ -1,0 +1,11 @@
+from typing import Protocol
+
+
+class Font(Protocol):
+    def getmask(
+        self,
+        text: str | bytes,
+        mode: str = ...,
+        direction=...,
+        features=...
+    ): ...

--- a/demotivator/typing.py
+++ b/demotivator/typing.py
@@ -14,3 +14,5 @@ class Font(Protocol):
 RGB: TypeAlias = tuple[int, int, int] | tuple[int, int, int, int]
 
 Ink: TypeAlias = str | int | RGB
+
+Color: TypeAlias = float | Ink | tuple[float] | tuple[int]

--- a/demotivator/typing.py
+++ b/demotivator/typing.py
@@ -1,4 +1,4 @@
-from typing import Protocol
+from typing import Protocol, TypeAlias
 
 
 class Font(Protocol):
@@ -9,3 +9,6 @@ class Font(Protocol):
         direction=...,
         features=...
     ): ...
+
+
+RGB: TypeAlias = tuple[int, int, int] | tuple[int, int, int, int]


### PR DESCRIPTION
Added `typing.py` module which contains type hints for the entire project

List of type hints:

1. Font
2. RGB
3. Ink
4. Color